### PR TITLE
add option N to print hiddent indented tree

### DIFF
--- a/src/FileIO.h
+++ b/src/FileIO.h
@@ -61,6 +61,8 @@ public:
     // Save hash‐table contents in table order back to a file
     void saveData(const std::string &outFilename) const;
 
+    void indentedTree(void visit(const string &item, int level));
+
 private:
     std::string fileName;
     std::ifstream inFile;
@@ -312,5 +314,10 @@ inline int FileIO::nextPrime(int n)
     }
     return n;
 }
+
+inline void FileIO::indentedTree(void visit(const string &item, int level)) 
+{
+    bst.printTree(visit);
+};
 
 #endif // FILEIO_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -196,7 +196,7 @@ int main()
                 cout << BOLD << GREEN << "Print indented tree!" << RESET << endl;
                 cout << "\n===== BST indented tree ===== " << endl;
                 file.indentedTree(iDisplay);
-                return 0;
+                break;
             }
 
             default:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,10 +156,6 @@ int main()
                 cout << BOLD << CYAN << "=========== All stored data in order ===========" << RESET << endl;
                 file.inOrder(hDisplay);
                 cout << endl;
-
-                // For debugging: hidden indented tree
-                // cout << "\n===== BST indented tree ===== " << endl;
-                // bst.printTree(iDisplay);
                 break;
             }
             case 'T':
@@ -192,6 +188,14 @@ int main()
             case 'Q':
             {
                 cout << BOLD << GREEN << "Thank you for visiting!" << RESET << endl;
+                return 0;
+            }
+
+            case 'N':
+            {
+                cout << BOLD << GREEN << "Print indented tree!" << RESET << endl;
+                cout << "\n===== BST indented tree ===== " << endl;
+                file.indentedTree(iDisplay);
                 return 0;
             }
 


### PR DESCRIPTION
Test:

```
Main Menu:
  [L] - Load data file
  [A] - Add data
  [S] - Search data (Primary key: creature_id)
  [D] - Delete data
  [U] - Undo delete
  [P] - Print data
  [T] - Show statistics
  [W] - Write to file
  [H] - Help
  [Q] - Quit
User command: l

Warning: Data file not loaded. All commands except for loading file are currently unavailable.    

What is the input file's name? Press Enter for Default "Creatures.txt": 
Reading data from "Creatures.txt..."
File Creatures.txt was successfully loaded!

User command: n
Print indented tree!

===== BST indented tree =====
1). FNKS-BD
..2). BSLSK-RE
....3). BGFT-HM
......4). BNSH-SP
....3). FFNR-DR
......4). DJNN-SP
........5). CRBR-HT
..........6). CHPC-CR
..2). KRKN-OC
....3). JMNG-SR
......4). FNRT-WF
........5). HYDR-RE
......4). KLP-MR
....3). XMR-CE
......4). QTZL-CS
........5). NIAN-BST
..........6). KTSN-SP
............7). MNTR-MN
..............8). MNTC-BT
................9). LNMS-CR
..................10). LVTH-BST
..........6). PXIE-SP
........5). THNB-BD
..........6). ROC-PR
............7). SLKI-MR
..............8). SPHX-MN
..........6). WNDB-HM
............7). TRSG-GB
......4). YTI-HM
........5). YNCR-UN
..........6). YLCT-FX

User command: 
```